### PR TITLE
use cv.CAP_GSTREAMER for video input

### DIFF
--- a/applications/smart-distancing/libs/core.py
+++ b/applications/smart-distancing/libs/core.py
@@ -1,3 +1,4 @@
+import os
 import time
 import cv2 as cv
 import numpy as np
@@ -75,7 +76,16 @@ class Distancing:
         return cv_image, objects_list, distancings
 
     def process_video(self, video_uri):
-        input_cap = cv.VideoCapture(video_uri)
+        if os.path.isfile(video_uri):
+            # if the input video_uri is a file, convert to file uri
+            # gstreamer's uridecodebin demands this format
+            video_uri = f'file://{os.path.abspath(video_uri)}'
+        # create the uridecodebin launch string.
+        # NOTE(mdegans): There are some optmizations that can go here, like only
+        # decoding video streams or using a more performant platform specific
+        # conversion elements, however videoconvert exists on all platforms
+        gst_launch_str = f'uridecodebin uri="{video_uri}" ! video/x-raw ! videoconvert ! appsink'
+        input_cap = cv.VideoCapture(gst_launch_str, cv.CAP_GSTREAMER)
 
         if (input_cap.isOpened()):
             print('opened video ', video_uri)


### PR DESCRIPTION
Here is an idea of how to do standard input sources with uridecodebin. rtsp sources will work, local sources will work, even YouTube will work with this techinque if you use something like youtube-dl to extract a valid uri.

This needs testing and more work to support camera sources, but it's an idea of how to do it. Edit: you might want to create a feature branch for this so that whoever picks it up can work from that.